### PR TITLE
Fixing Makefile with newer golang files that work on FreeBSD 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,9 @@ init: ## Install requirements
 	@go get -u github.com/golang/glog
 	@go get -u github.com/kardianos/govendor
 	@go get -u github.com/Masterminds/rmvcsdir
-	@go get -u github.com/golang/lint/golint
+	#@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/lint
+	@go get -u golang.org/x/crypto/ssh/terminal
 	@go get -u github.com/kisielk/errcheck
 	@go get -u golang.org/x/tools/cmd/guru
 	@go get -u github.com/mitchellh/gox


### PR DESCRIPTION
Fixed for building in TrueNAS 12 Jail.  

have to proceed with 
  pkg install golint golangci-lint